### PR TITLE
Add generic payload typing on dispatch method

### DIFF
--- a/adonis-typings/index.ts
+++ b/adonis-typings/index.ts
@@ -16,7 +16,11 @@ declare module '@ioc:Setten/Queue' {
 	};
 
 	interface QueueContract {
-		dispatch(job: string, payload: Record<string, unknown>, options?: JobsOptions): Promise<string>;
+		dispatch<D = Record<string, unknown>>(
+			job: string,
+			payload: D,
+			options?: JobsOptions
+		): Promise<string>;
 		process(): Promise<void>;
 	}
 

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -25,7 +25,7 @@ export class BullManager {
 		});
 	}
 
-	public dispatch(job: string, payload: Record<string, unknown>, options: JobsOptions = {}) {
+	public dispatch<D = Record<string, unknown>>(job: string, payload: D, options: JobsOptions = {}) {
 		return this.queue.add(job, payload, {
 			...this.options.jobs,
 			...options,


### PR DESCRIPTION
Hello 👋 

I saw the note in your readme

> Note: There is currently no typing support for job payloads.

You can let the user set it's own interface for the payload with a generic on the dispatch method

```ts

interface MyJobPayload {
 message: string;
}

Queue.dispatch< MyJobPayload >(
  'App/Jobs/RegisterStripeCustomer',
  { 
   message: "Hello job", // 👈 should force MyInterface for the payload
  },  
);
```

Hope it's helps