### PR TITLE
Add support for multiple queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ It will dispatch the linked job to the queue with the given payload.
 import { Queue } from '@ioc:Setten/Queue';
 
 Queue.dispatch('App/Jobs/RegisterStripeCustomer', {...});
+
+
+Queue.dispatch('App/Jobs/RegisterStripeCustomer', {...}, {
+  queueName: 'stripe',
+});
 ```
 
 Your `Job` can be stored anywhere in your application and is dispatched using its full path.
@@ -65,6 +70,10 @@ Run the queue worker with the following ace command:
 
 ```bash
 node ace queue:listen
+
+# or
+
+node ace queue:listen --queue=stripe
 ```
 
 Once done, you will see the message `Queue processing started`.

--- a/commands/QueueListener.ts
+++ b/commands/QueueListener.ts
@@ -5,11 +5,14 @@
  * @copyright Setten - Romain Lanz <romain.lanz@setten.io>
  */
 
-import { BaseCommand } from '@adonisjs/core/build/standalone';
+import { BaseCommand, flags } from '@adonisjs/core/build/standalone';
 
 export default class QueueListener extends BaseCommand {
 	public static commandName = 'queue:listen';
 	public static description = '';
+
+	@flags.string({ alias: 'q', description: 'The queue to listen on' })
+	public queue: string = 'default';
 
 	public static settings = {
 		loadApp: true,
@@ -19,6 +22,8 @@ export default class QueueListener extends BaseCommand {
 	public async run() {
 		const { Queue } = this.application.container.resolveBinding('Setten/Queue');
 
-		await Queue.process();
+		await Queue.process({
+			queueName: this.queue,
+		});
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "moduleResolution": "Node",
     "outDir": "build",
     "useDefineForClassFields": true,
+    "experimentalDecorators": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2020",


### PR DESCRIPTION
Usage:

```js
import { Queue } from '@ioc:Setten/Queue';

Queue.dispatch('App/Jobs/RegisterStripeCustomer', {...}, {
  queueName: 'stripe',
});
```

```sh
node ace queue:listen --queue=stripe
```
