### PR TITLE
Add support for `attempts` and `backoff`

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -3,7 +3,7 @@ The package has been configured successfully. The queue configuration stored ins
 **Open the `env.ts` file and paste the following code inside the `Env.rules` object.**
 
 ```ts
-QUEUE_REDIS_HOST = Env.schema.string({ format: 'host' }),
-QUEUE_REDIS_PORT = Env.schema.number(),
-QUEUE_REDIS_PASSWORD = Env.schema.string(),
+QUEUE_REDIS_HOST: Env.schema.string({ format: 'host' }),
+QUEUE_REDIS_PORT: Env.schema.number(),
+QUEUE_REDIS_PASSWORD: Env.schema.string.optional(),
 ```

--- a/templates/config.txt
+++ b/templates/config.txt
@@ -14,6 +14,10 @@ const queueConfig: QueueConfig = {
 
   jobs: {
     attempts: 3,
+    backoff: {
+      type: 'exponential',
+      delay: 1000,
+    },
   }
 }
 


### PR DESCRIPTION
Added `QueueScheduler` to support many BullMQ features, like `attempts` and `backoff`

![image](https://user-images.githubusercontent.com/9212274/183428000-0400e7cf-c796-4b77-8528-6f71e6cf4a4d.png)
